### PR TITLE
Add documentation to use Github Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Run the tool through the context menu on a file or directory:
 
 </details>
 
-### Workflow in Github Workflow
+### Workflow for Github Workflow
 
 <details>
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Add the following file in the following location:
 
 Insert the following into optimizt.yml
 ```yml
-name: AVIF
+name: optimizt
 on:
   # Triggers the workflow on push or pull request events but only for the main branch and only when there's JPG/JPEG/PNG in the commmit!
   push:
@@ -336,7 +336,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  Convert-to-WEBP:
+  Run Optimizt:
     runs-on: ubuntu-latest
     env:
       OPTIMIZTCONVERTERARGS: --avif --webp . # convert to avif and webp for all JPG/JPEG/PNG files in this folder
@@ -360,18 +360,76 @@ jobs:
           jpegProgressive: false
           pngQuality: '80'
           webpQuality: "80"
-      #- name: Commit files
-      #  run: |
-      #    git add .
-      #    git config --local user.email "actions@github.com"
-      #    git config --local user.name "github-actions[bot]"
-      #    git diff --quiet && git diff --staged --quiet || git commit -am "Converted all JPG/JPEG/PNG files into compressed WEBP & AVIF"
-      #- name: Push changes
-      #  uses: ad-m/github-push-action@master # This is a premade github action
-      #  with:
-      #    github_token: ${{ secrets.GITHUB_TOKEN }}
-      #    branch: ${{ github.ref }}
+      - name: Commit files
+        run: |
+          git add .
+          git config --local user.email "actions@github.com"
+          git config --local user.name "github-actions[bot]"
+          git diff --quiet && git diff --staged --quiet || git commit -am "Converted all JPG/JPEG/PNG files into compressed WEBP & AVIF"
+      - name: Push changes
+        uses: ad-m/github-push-action@master # This is a premade github action
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+```
+
+#### What does it do?
+
+This workflow will trigger whenever a jpg, jpeg or png file is added, removed or changed.
+Then the workflow will install optimizt trough npm with sudo and --unsafe-perm to install it successfully.
+The current repository will be checkout and then optimizt will do the following by default:
+- Create AVIF from all images in the repository
+- Create WEBP from all images in the repository
+Next calibre is used to compress the jpg, jpeg, png and webp files futher with 80% quality.
+
+#### Push changes trough commit
+
+The current workflow will push changes based on commit.
+
+#### Push changes trough pull
+
+If the changes need to be pusht as a pull request. It's adviced NOT to use the on trigger push. As this will create a loop which means you have to close the next pull request yourself. Other options to trigger are to use a sceduel (cron) or simply manually hit the button to start the workflow. The following would be sufficient to create the changes in a pull request.
+
+```yml
+name: optimizt
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+   - cron: "0 0 * * *" # Every day at 00:00 UTC
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  Run Optimizt:
+    runs-on: ubuntu-latest
+    env:
+      OPTIMIZTCONVERTERARGS: --avif --webp . # convert to avif and webp for all JPG/JPEG/PNG files in this folder
+    steps:
+      - name: Install dependencies
+        run: | # install optimizt
+          sudo npm i -g @funboxteam/optimizt --unsafe-perm
+      - uses: actions/checkout@v2 # This is a premade github action
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+      - name: run optimizt
+        run: optimizt ${OPTIMIZTCONVERTERARGS}
+      - name: Compress Images
+        id: calibre
+        uses: calibreapp/image-actions@main
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          compressOnly: true # Needed to not get a pullrequest and just compress
+          jpegQuality: '80'
+          jpegProgressive: false
+          pngQuality: '80'
+          webpQuality: "80"
       - name: Create Pull Request
+        # If it's not a Pull Request then commit any changes as a new PR.
+        if: |
+          github.event_name != 'pull_request' &&
+          steps.calibre.outputs.markdown != ''
         uses: peter-evans/create-pull-request@v3
         with:
           delete-branch: true
@@ -395,26 +453,7 @@ jobs:
             As the newer pull will be based on a more recent commit and will include the current changes aswell
       
             Delete the Branch after the pull is merged.
-
 ```
-
-#### What does it do?
-
-This workflow will trigger whenever a jpg, jpeg or png file is added, removed or changed.
-Then the workflow will install optimizt trough npm with sudo and --unsafe-perm to install it successfully.
-The current repository will be checkout and then optimizt will do the following by default:
-- Create AVIF from all images in the repository
-- Create WEBP from all images in the repository
-Next calibre is used to compress the jpg, jpeg, png and webp files futher with 80% quality.
-
-#### Push changes trough commit
-
-If the changes need to be pushed trough commit automatically, comment out the: `Create Pull Request` task entirely.
-Uncomment the `Commit files` task entirely.
-
-#### Push changes trough pull
-
-If the changes need to be push trough a pull request, the configuration as is will achieve this.
 
 </details>
 


### PR DESCRIPTION
This pull request adds information and the Workflow to automate the process of creating AVIF and WEBP images based on changes on jpg/jpeg/png files on commit.

This workflow contains only the way how to push the changes, not pull.

I tested both ways but noticed that the pull methode can create a loop. As accepting the pull makes a new commit that isn't from a workflow user. The compression on jpg/jpeg/png seems to not be applied as these files were actually converted from compressed webp.

This pull does contain work from calibreapp/image-actions@main. I believe it adds even more functionality to the workflow as images are futher compressed which safes even more. I know optimizt has this aswell for jpg/jpeg/png but not for webp i believe. *I would like to hear if this decision is ok, otherwise i remove that part and/or edit the workflow to include the compression from optimizt.*

[Proof of commit based](https://github.com/TheVoxSiren/voxsiren.net/tree/32ecb1213173e6b6b56b8aba7a65140d6694e6dd/assets/images
)
[Proof of pull based](https://github.com/TheVoxSiren/voxsiren.net/pull/17). Note that a new file was added later (work-process-item-01.png) and this one was also added to the pull request.

A few things i would like to adres
- When i tried to install withoud sudo it obviously gave this [error](work-process-item-01.webp). But with sudo i got this [error](https://github.com/TheVoxSiren/voxsiren.net/runs/2043280708?check_suite_focus=true). I'm not sure if this is a problem but i could fix it with [`--unsafe-perm`](https://github.com/TheVoxSiren/voxsiren.net/runs/2043298394?check_suite_focus=true). Does this need fixing or is this ok?
- A problem might occure if the user removes a webp or avif file. This workflow does not check for these types of files. I think it wouldn't make sense to also check on these files because of the following two reasons:
1. The user removed the image for a reason, if they edit the png/jpg/jpeg it'll get replaced anyways.
2. If the user adds their own avif/webp image, the workflow wouldn't output anything. As optimizt doesn't convert from webp/avif to avif/webp (rightfully so).
While issue 2 doesn't seem to be much of a problem, the first issue would but it would be rather a user error rather then the faulth of the workflow. But i don't see the point of checking on changes of webp/avif.
- I will include the pull request code here, but users should not trigger this build by commit. Rather any other means will do, as that won't retrigger it.

I believe i mentioned everything that i had to mention. The workflow works great based on commit and push. It's just the pull that i can't fix. Just let me know if ya guys want the calibri part to be in or not. Idk if ya can futher compress AVIF, or if optimizt can do this. But please let me know as i love to save even more on images :).