### PR TITLE
Disable `removeOffCanvasPaths` in SVGO config

### DIFF
--- a/.optimiztrc.js
+++ b/.optimiztrc.js
@@ -114,7 +114,6 @@ export default {
         'convertEllipseToCircle',
         'sortAttrs',
         'sortDefsChildren',
-        'removeOffCanvasPaths',
         'reusePaths',
       ],
     },


### PR DESCRIPTION
There are known issues marked as bugs: https://github.com/svg/svgo/issues/1732, https://github.com/svg/svgo/issues/1646